### PR TITLE
Fix the 6-bit Caught Level to record Pokemon > Level 63

### DIFF
--- a/constants/pokemon_data_constants.asm
+++ b/constants/pokemon_data_constants.asm
@@ -78,7 +78,11 @@ MON_SPECIES            rb
 MON_ITEM               rb
 MON_MOVES              rb NUM_MOVES
 MON_ID                 rw
-MON_EXP                rb 3
+MON_EXP                rb
+rsset MON_EXP
+MON_CAUGHTTIME         rb
+MON_EXP2               rb
+MON_EXP3               rb
 MON_STAT_EXP           rw NUM_EXP_STATS
 rsset MON_STAT_EXP
 MON_HP_EXP             rw
@@ -92,7 +96,7 @@ MON_HAPPINESS          rb
 MON_POKERUS            rb
 MON_CAUGHTDATA         rw
 rsset MON_CAUGHTDATA
-MON_CAUGHTTIME         rb
+MON_EMPTY_BIT          rb
 MON_CAUGHTGENDER       rb
 rsset MON_CAUGHTDATA
 MON_CAUGHTLEVEL        rb
@@ -115,10 +119,11 @@ PARTYMON_STRUCT_LENGTH EQU _RS
 NICKNAMED_MON_STRUCT_LENGTH EQU PARTYMON_STRUCT_LENGTH + MON_NAME_LENGTH
 REDMON_STRUCT_LENGTH EQU 44
 
-; caught data
+; experience data
+CAUGHT_TIME_MASK EQU %11000000
+EXP_MASK         EQU %00111111
 
-CAUGHT_TIME_MASK  EQU %11000000
-CAUGHT_LEVEL_MASK EQU %00111111
+; caught data
 
 CAUGHT_GENDER_MASK   EQU %10000000
 CAUGHT_LOCATION_MASK EQU %01111111

--- a/constants/pokemon_data_constants.asm
+++ b/constants/pokemon_data_constants.asm
@@ -96,7 +96,7 @@ MON_HAPPINESS          rb
 MON_POKERUS            rb
 MON_CAUGHTDATA         rw
 rsset MON_CAUGHTDATA
-MON_EMPTY_BIT          rb
+                       rb_skip
 MON_CAUGHTGENDER       rb
 rsset MON_CAUGHTDATA
 MON_CAUGHTLEVEL        rb

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -7139,10 +7139,20 @@ GiveExperiencePoints:
 	ld [hl], a
 	jr nc, .no_exp_overflow
 	dec hl
+	push bc
+	push af
+	ld a, [hl]
+	and EXP_MASK
+	ld b, a
 	inc [hl]
+	pop af
+	ld a, b
+	pop bc
+	inc a
 	jr nz, .no_exp_overflow
-	ld a, $ff
+	ld a, EXP_MASK
 	ld [hli], a
+	ld a, $ff
 	ld [hli], a
 	ld [hl], a
 
@@ -7173,13 +7183,19 @@ GiveExperiencePoints:
 	ld a, [hld]
 	sbc c
 	ld a, [hl]
+	push af
+	and EXP_MASK
+	ld d, a
+	pop af
+	ld a, d
 	sbc b
 	jr c, .not_max_exp
 	ld a, b
 	ld [hli], a
 	ld a, c
 	ld [hli], a
-	ld a, d
+	ldh a, [hQuotient + 3]
+	ld d, a
 	ld [hld], a
 
 .not_max_exp
@@ -7470,9 +7486,13 @@ AnimateExpBar:
 	ld [hld], a
 	jr nc, .NoOverflow
 	inc [hl]
+	ld a, [hl]
+	and EXP_MASK
+	and a
 	jr nz, .NoOverflow
-	ld a, $ff
+	ld a, EXP_MASK
 	ld [hli], a
+	ld a, $ff
 	ld [hli], a
 	ld [hl], a
 
@@ -7491,13 +7511,22 @@ AnimateExpBar:
 	ld a, [hld]
 	sbc c
 	ld a, [hl]
+	push de
+	push af
+	and EXP_MASK
+	ld d, a
+	pop af
+	ld a, d
 	sbc b
+	pop de
 	jr c, .AlreadyAtMaxExp
 	ld a, b
 	ld [hli], a
 	ld a, c
 	ld [hli], a
-	ld a, d
+	ld a, [hl]
+	and CAUGHT_TIME_MASK
+	or d
 	ld [hld], a
 
 .AlreadyAtMaxExp:
@@ -7878,6 +7907,13 @@ CalcExpBar:
 	sbc b
 	ld [hld], a
 	ld a, [de]
+	push de
+	push af
+	and EXP_MASK
+	ld d, a
+	pop af
+	ld a, d
+	pop de
 	ld c, a
 	ldh a, [hMathBuffer]
 	sbc c

--- a/engine/events/happiness_egg.asm
+++ b/engine/events/happiness_egg.asm
@@ -158,9 +158,16 @@ DayCareStep::
 	dec hl
 	inc [hl]
 	ld a, [hl]
+	and EXP_MASK
 	cp HIGH(MAX_DAY_CARE_EXP >> 8)
 	jr c, .day_care_lady
+	push de
+	ld a, [hl]
+	and CAUGHT_TIME_MASK
+	ld d, a
 	ld a, HIGH(MAX_DAY_CARE_EXP >> 8)
+	or d
+	pop de
 	ld [hl], a
 
 .day_care_lady
@@ -180,9 +187,16 @@ DayCareStep::
 	dec hl
 	inc [hl]
 	ld a, [hl]
+	and EXP_MASK
 	cp HIGH(MAX_DAY_CARE_EXP >> 8)
 	jr c, .check_egg
+	push de
+	ld a, [hl]
+	and CAUGHT_TIME_MASK
+	ld d, a
 	ld a, HIGH(MAX_DAY_CARE_EXP >> 8)
+	or d
+	pop de
 	ld [hl], a
 
 .check_egg

--- a/engine/events/poke_seer.asm
+++ b/engine/events/poke_seer.asm
@@ -95,10 +95,17 @@ SeerAction4:
 	ret
 
 ReadCaughtData:
+	ld a, MON_CAUGHTTIME
+	call GetPartyParamLocation
+	ld a , [hl]
+	and CAUGHT_TIME_MASK
+	rlca
+	rlca
+	ld [wSeerCaughtTime], a
 	ld a, MON_CAUGHTDATA
 	call GetPartyParamLocation
 	ld a, [hli]
-	ld [wSeerCaughtData], a
+	ld [wSeerCaughtLevel], a
 	ld a, [hld]
 	ld [wSeerCaughtGender], a
 	or [hl]
@@ -153,8 +160,8 @@ GetCaughtLevel:
 
 	; caught level
 	; Limited to between 1 and 63 since it's a 6-bit quantity.
-	ld a, [wSeerCaughtData]
-	and CAUGHT_LEVEL_MASK
+	ld a, [wSeerCaughtLevel]
+	and a
 	jr z, .unknown
 	cp CAUGHT_EGG_LEVEL ; egg marker value
 	jr nz, .print
@@ -179,12 +186,10 @@ GetCaughtLevel:
 	db "???@"
 
 GetCaughtTime:
-	ld a, [wSeerCaughtData]
-	and CAUGHT_TIME_MASK
+	ld a, [wSeerCaughtTime]
+	and a
 	jr z, .none
 
-	rlca
-	rlca
 	dec a
 	ld hl, .times
 	call GetNthString

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -1321,7 +1321,14 @@ RareCandyEffect:
 	ld a, MON_EXP
 	call GetPartyParamLocation
 
+	push de
+	ld a, [hl]
+	and CAUGHT_TIME_MASK
+	ld d, a
 	ldh a, [hMultiplicand + 0]
+	and EXP_MASK
+	or d
+	pop de
 	ld [hli], a
 	ldh a, [hMultiplicand + 1]
 	ld [hli], a

--- a/engine/pokemon/caught_data.asm
+++ b/engine/pokemon/caught_data.asm
@@ -163,16 +163,26 @@ CaughtAskNicknameText:
 SetCaughtData:
 	ld a, [wPartyCount]
 	dec a
-	ld hl, wPartyMon1CaughtLevel
+;	ld hl, wPartyMon1CaughtLevel
+	ld hl, wPartyMon1CaughtTime
 	call GetPartyLocation
 SetBoxmonOrEggmonCaughtData:
+	ld a, [hl]
+	and EXP_MASK
+	ld b, a
 	ld a, [wTimeOfDay]
 	inc a
 	rrca
 	rrca
-	ld b, a
-	ld a, [wCurPartyLevel]
 	or b
+	ld [hl], a
+	ld a, (wPartyMon1CaughtLevel - wPartyMon1CaughtTime)
+	add l
+	ld l, a
+	adc h
+	sub l
+	ld h, a
+	ld a, [wCurPartyLevel]
 	ld [hli], a
 	ld a, [wMapGroup]
 	ld b, a
@@ -199,18 +209,18 @@ SetBoxmonOrEggmonCaughtData:
 	ret
 
 SetBoxMonCaughtData:
-	ld a, BANK(sBoxMon1CaughtLevel)
+	ld a, BANK(sBoxMon1CaughtTime)
 	call OpenSRAM
-	ld hl, sBoxMon1CaughtLevel
+	ld hl, sBoxMon1CaughtTime
 	call SetBoxmonOrEggmonCaughtData
 	call CloseSRAM
 	ret
 
 SetGiftBoxMonCaughtData:
 	push bc
-	ld a, BANK(sBoxMon1CaughtLevel)
+	ld a, BANK(sBoxMon1CaughtTime)
 	call OpenSRAM
-	ld hl, sBoxMon1CaughtLevel
+	ld hl, sBoxMon1CaughtTime
 	pop bc
 	call SetGiftMonCaughtData
 	call CloseSRAM
@@ -219,7 +229,7 @@ SetGiftBoxMonCaughtData:
 SetGiftPartyMonCaughtData:
 	ld a, [wPartyCount]
 	dec a
-	ld hl, wPartyMon1CaughtLevel
+	ld hl, wPartyMon1CaughtTime
 	push bc
 	call GetPartyLocation
 	pop bc
@@ -234,7 +244,7 @@ SetGiftMonCaughtData:
 
 SetEggMonCaughtData:
 	ld a, [wCurPartyMon]
-	ld hl, wPartyMon1CaughtLevel
+	ld hl, wPartyMon1CaughtTime
 	call GetPartyLocation
 	ld a, [wCurPartyLevel]
 	push af

--- a/engine/pokemon/experience.asm
+++ b/engine/pokemon/experience.asm
@@ -22,6 +22,13 @@ CalcLevel:
 	ldh a, [hProduct + 1]
 	ld c, a
 	ld a, [hl]
+	push de
+	push af
+	and EXP_MASK
+	ld d, a
+	pop af
+	ld a, d
+	pop de
 	sbc c
 	pop hl
 	jr nc, .next_level

--- a/engine/pokemon/move_mon.asm
+++ b/engine/pokemon/move_mon.asm
@@ -889,7 +889,13 @@ RetrieveBreedmon:
 	pop bc
 	ld hl, MON_EXP
 	add hl, bc
+	ld a, [hl]
+	and CAUGHT_TIME_MASK
+	push de
+	ld d, a
 	ldh a, [hMultiplicand]
+	or d
+	pop de
 	ld [hli], a
 	ldh a, [hMultiplicand + 1]
 	ld [hli], a

--- a/engine/pokemon/stats_screen.asm
+++ b/engine/pokemon/stats_screen.asm
@@ -633,6 +633,14 @@ LoadPinkPage:
 	hlcoord 13, 10
 	lb bc, 3, 7
 	ld de, wTempMonExp
+	ld a, [de]
+	and EXP_MASK
+	ld [wStringBuffer1], a
+	ld a, [wTempMonExp + 1]
+	ld [wStringBuffer1 + 1], a
+	ld a, [wTempMonExp + 2]
+	ld [wStringBuffer1 + 2], a
+	ld de, wStringBuffer1
 	call PrintNum
 	call .CalcExpToNextLevel
 	hlcoord 13, 13
@@ -677,7 +685,6 @@ LoadPinkPage:
 	ld d, a
 	farcall CalcExpAtLevel
 	ld hl, wTempMonExp + 2
-	ld hl, wTempMonExp + 2
 	ldh a, [hQuotient + 3]
 	sub [hl]
 	dec hl
@@ -687,7 +694,14 @@ LoadPinkPage:
 	dec hl
 	ld [wExpToNextLevel + 1], a
 	ldh a, [hQuotient + 1]
-	sbc [hl]
+	push af
+	ld e, a
+	ld a, [hl]
+	and EXP_MASK
+	ld d, a
+	pop af
+	ld a, e
+	sbc d
 	ld [wExpToNextLevel], a
 	ret
 

--- a/macros/wram.asm
+++ b/macros/wram.asm
@@ -9,6 +9,7 @@ box_struct: MACRO
 \1Item::           db
 \1Moves::          ds NUM_MOVES
 \1ID::             dw
+\1CaughtTime::
 \1Exp::            ds 3
 \1StatExp::
 \1HPExp::          dw
@@ -21,7 +22,6 @@ box_struct: MACRO
 \1Happiness::      db
 \1PokerusStatus::  db
 \1CaughtData::
-\1CaughtTime::
 \1CaughtLevel::    db
 \1CaughtGender::
 \1CaughtLocation:: db

--- a/wram.asm
+++ b/wram.asm
@@ -1848,7 +1848,7 @@ wSeerOT:: ds NAME_LENGTH
 wSeerOTGrammar:: db
 wSeerCaughtLevelString:: ds 4
 wSeerCaughtLevel:: db
-wSeerCaughtData:: db
+wSeerCaughtTime:: db
 wSeerCaughtGender:: db
 
 


### PR DESCRIPTION
We fix this by moving the `CAUGHT_TIME_MASK` bits (%11000000) to the first byte in `MON_EXP`. `MON_EXP` has three free bits that are never used. This gives `MON_CAUGHTLEVEL` a whole byte to itself, with one free bit.

This is related to pret#901